### PR TITLE
Support pullable sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "callbag"
   ],
   "devDependencies": {
-    "callbag-mock": "^1.0.0",
-    "tape": "^4.8.0",
-    "ts-node": "^5.0.0",
-    "typescript": "^2.7.2",
     "callbag-for-each": "^1.0.1",
     "callbag-from-iter": "^1.0.0",
-    "callbag-pipe": "^1.1.1"
+    "callbag-mock": "^1.0.0",
+    "callbag-pipe": "^1.1.1",
+    "tape": "^4.8.0",
+    "ts-node": "^5.0.0",
+    "typescript": "^2.7.2"
   },
   "dependencies": {}
 }

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -7,8 +7,13 @@
 export function debounce(wait: number): any {
   return (source: any) => (start: number, sink: any) => {
     if (start !== 0) return;
+    let ask: any;
     let timeout: number | undefined;
     source(0, (t: number, d: any) => {
+      if (t === 0) {
+        ask = d;
+      }
+
       if (t === 1 || (t === 2 && d === undefined)) {
         // t === 1 means the source is emitting a value
         // t === 2 and d === undefined means the source emits a completion
@@ -22,11 +27,12 @@ export function debounce(wait: number): any {
           sink(t, d);
           timeout = undefined;
         }, wait);
+
+        if (t === 1) {
+          ask(1)
+        }
       }
       /*
-       * no need to handle the t === 0 case because
-       * the operator never needs to talkback to the source
-       *
        * nothing specific to do when the source
        * sends a t === 2 d !== undefined signal
        */

--- a/test.ts
+++ b/test.ts
@@ -2,6 +2,7 @@ const test = require("tape");
 
 const pipe = require("callbag-pipe");
 const forEach = require("callbag-for-each");
+const fromIter = require("callbag-from-iter");
 const mock = require("callbag-mock");
 
 import { debounce } from "./src/debounce";
@@ -112,4 +113,32 @@ test("it should send completion after the last emission", t => {
   source.emit(1, "event");
   source.emit(2);
 
+});
+
+
+test("it should with pullable source", t => {
+  t.plan(2);
+  const actual = []
+
+  const timeStart = Date.now();
+  const debounceValue = 1000;
+
+  pipe(
+    fromIter([1, 2, 3]),
+    debounce(debounceValue),
+    s => (start, sink) => {
+      if (start !== 0) return;
+      s(0, (st, d) => {
+        if (st === 2) {
+          const exeTime = Date.now() - timeStart;
+          t.ok(exeTime >= debounceValue);
+          t.equals(actual.length, 0);
+        }
+        sink(st, d);
+      });
+    },
+    forEach((value) => {
+      actual.push(value);
+    }),
+  );
 });


### PR DESCRIPTION
Actually this is pretty useless now - it only exhausts the pullable source (which I guess is something 😉 ).  In a followup PR I can tweak this, but we'd have to establish what completions should do with a pending value and if completions should be debounced too. Various stream libraries do various things for those, so there is no "right answer" here - more about differences in other implementations can be found [here](https://github.com/atomrc/callbag-debounce/issues/2#issuecomment-378396988)