### PR TITLE
Fix lack of timer cleanup when terminated by sink.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,15 @@
       "integrity": "sha512-gPTHExrElPAOu/s91aySM1dCGCuQhbTLvvHwrqI/2aMW0qOda2nCZpmE0ML94l2tDy6Y4fqlI1SyAxqgLkZl6w==",
       "dev": true
     },
+    "callbag-subscribe": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/callbag-subscribe/-/callbag-subscribe-1.5.1.tgz",
+      "integrity": "sha512-CRj2jKfcRvG8gap2ehsm/NxZVAjnwUApI+0ZY3bu6nyFfhhOzH+4RWpB/4RSJUZNN3ZILdSgAKQiUov/7ov9BQ==",
+      "dev": true,
+      "requires": {
+        "callbag": "^1.2.0"
+      }
+    },
     "chalk": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "callbag-from-iter": "^1.0.0",
     "callbag-mock": "^1.0.0",
     "callbag-pipe": "^1.1.1",
+    "callbag-subscribe": "^1.5.1",
     "tape": "^4.8.0",
     "ts-node": "^5.0.0",
     "typescript": "^3.8.3"

--- a/test.ts
+++ b/test.ts
@@ -3,6 +3,7 @@ const test = require("tape");
 const pipe = require("callbag-pipe");
 const forEach = require("callbag-for-each");
 const mock = require("callbag-mock");
+const subscribe = require("callbag-subscribe");
 
 import { debounce } from "./src/debounce";
 
@@ -112,4 +113,25 @@ test("it should send completion after the last emission", t => {
   source.emit(1, "event");
   source.emit(2);
 
+});
+
+test("it should not emit after unsubscribe", t => {
+  t.plan(1);
+
+  const source = mock("source", () => {}, true);
+  let res = false;
+  const unsubscribe = pipe(
+    source,
+    debounce(2),
+    subscribe(v => {
+      res = v;
+    })
+  );
+
+  source.emit(1, true);
+  unsubscribe();
+
+  setTimeout(() => {
+    t.equal(res, false);
+  }, 5);
 });


### PR DESCRIPTION
Cleans up timer when terminated by sink. This resolves an issue that shows up when using debounce when switching between callbag streams  (ala RXJS SwitchMap).

See https://stackblitz.com/edit/typescript-ufcfks?file=index.ts

```
import { interval, merge, map, forEach, pipe, flatten } from "callbag-basics";
import of from "callbag-of";
import wait from "callbag-wait";
import { debounce } from "callbag-debounce";

pipe(
  // start with 0, then pass 1 after 4 seconds
  merge(
    of(0),
    pipe(
      of(1),
      wait(2000)
    )
  ),
  map(val => {
    if (val === 0) {
      // when 0, pass a stream with some noisy input data
      return pipe(
        // some data that shows up randomly
        merge(interval(1000 / 5), interval(1000 / 6), interval(1000 / 7)),
        // but debounce it
        debounce(111),
        map(val => `noisy ${val}`)
      );
    } else {
      // when 1, pass a stream of 'complete'
      return of("complete");
    }
  }),
  // take the values from the most recent stream
  // ala RXJS switchmap
  flatten,
  // but we recieve a noisy data value after
  // switching to the complete stream because
  // debounce fails to handle the 'terminate'
  // signal from its sink
  forEach(val => console.log(val))
);
```